### PR TITLE
Building sudo on NetBSD

### DIFF
--- a/bucket_83/sudo
+++ b/bucket_83/sudo
@@ -46,6 +46,7 @@ CONFIGURE_ARGS=		--sysconfdir={{PREFIX}}/etc
 INSTALL_REQ_TOOLCHAIN=	yes
 
 VAR_OPSYS[dragonfly]=	CONFIGURE_ARGS=--enable-hardening=no
+VAR_OPSYS[netbsd]=	CONFIGURE_ARGS=--without-pam
 
 post-patch:
 	${REINPLACE_CMD} -E '/install-(binaries|noexec):/,/^$$/ \


### PR DESCRIPTION
Package fails to build due to pam, this adds in a line to compile with `--without-pam` as a configure argument.